### PR TITLE
CE-0005 Fix silent guard defects in all three modify endpoints

### DIFF
--- a/api/bike-api.yaml
+++ b/api/bike-api.yaml
@@ -99,6 +99,8 @@ paths:
                 $ref: '#/components/schemas/Bike'
         '400':
           description: Bad Request
+        '404':
+          description: Not Found
         '500':
           description: Internal Server Error
     delete:

--- a/api/parts-api.yaml
+++ b/api/parts-api.yaml
@@ -120,6 +120,8 @@ paths:
                 $ref: '#/components/schemas/Part'
         '400':
           description: Bad Request
+        '404':
+          description: Not Found
         '500':
           description: Internal Server Error
     delete:
@@ -240,6 +242,8 @@ paths:
                 $ref: '#/components/schemas/PartType'
         '400':
           description: Bad Request
+        '404':
+          description: Not Found
         '500':
           description: Internal Server Error
     delete:

--- a/src/main/kotlin/de/cyclingsir/cetrack/bike/domain/BikeService.kt
+++ b/src/main/kotlin/de/cyclingsir/cetrack/bike/domain/BikeService.kt
@@ -39,11 +39,18 @@ class BikeService(private val repository: BikeRepository, private val mapper: Bi
     }
 
     fun modifyBike(bikeId: UUID, bike: DomainBike): DomainBike? {
+        if (bike.id != null && bike.id != bikeId) {
+            throw ServiceException(ErrorCodesDomain.BIKE_ID_MISMATCH)
+        }
+        if (!repository.existsById(bikeId)) {
+            throw ServiceException(ErrorCodesDomain.BIKE_NOT_FOUND)
+        }
+        val entity = mapper.map(bike)
+        entity.id = bikeId
         val bikeEntity = try {
-            assert(bikeId == bike.id)
-            repository.save(mapper.map(bike))
+            repository.save(entity)
         } catch (e: Exception) {
-            throw ServiceException(ErrorCodesDomain.BIKE_NOT_PERSISTED, e.message)
+            throw ServiceException(ErrorCodesDomain.BIKE_NOT_PERSISTED, e.message ?: "Persisting failed", e)
         }
         return mapper.map(bikeEntity)
     }

--- a/src/main/kotlin/de/cyclingsir/cetrack/common/errorhandling/ErrorCodesDomain.kt
+++ b/src/main/kotlin/de/cyclingsir/cetrack/common/errorhandling/ErrorCodesDomain.kt
@@ -13,14 +13,17 @@ enum class ErrorCodesDomain(
     PART_TYPE_NOT_PERSISTED(102, 404, "PartType not found"),
     PART_NOT_IDENTIFIABLE(103, 400, "A part must have at least a label or a model"),
     PART_PRICE_CURRENCY_MISMATCH(104, 400, "Purchase price and currency code must be provided together"),
+    PART_ID_MISMATCH(105, 400, "Path id does not match the part id in the body"),
+    PART_TYPE_ID_MISMATCH(106, 400, "Path id does not match the part type id in the body"),
 
     RELATION_NOT_VALID(200, 400, "Relation not valid"),
 
     PREVIOUS_RELATION_NOT_FOUND(201, 400, "Previous relation to finalize not found"),
 
-    BIKE_NOT_FOUND(300, 400, "Bike not found"),
+    BIKE_NOT_FOUND(300, 404, "Bike not found"),
     BIKE_NOT_PERSISTED(301, 404, "Unable to persist bike"),
     BIKE_HAS_FOREIGN_KEY_CONSTRAINT(302, 400, "Bike can't be deleted."),
+    BIKE_ID_MISMATCH(303, 400, "Path id does not match the bike id in the body"),
 
     TOUR_DUPLICATE(400, 409, "Tour already exists");
 

--- a/src/main/kotlin/de/cyclingsir/cetrack/part/domain/PartService.kt
+++ b/src/main/kotlin/de/cyclingsir/cetrack/part/domain/PartService.kt
@@ -82,17 +82,23 @@ final class PartService(
 
     fun modifyPart(partId: UUID, part: DomainPart): DomainPart? {
         logger.debug { "Modify Part for part ${part} was called!" }
-        assert(partId == part.id)
+        if (part.id != null && part.id != partId) {
+            throw ServiceException(ErrorCodesDomain.PART_ID_MISMATCH)
+        }
+        if (!partRepository.existsById(partId)) {
+            throw ServiceException(ErrorCodesDomain.PART_NOT_FOUND)
+        }
         requireIdentifiable(part)
         requirePricePair(part)
         logger.debug { "DomainPart: ${part}" }
         val entity = mapper.map(part)
+        entity.id = partId
         logger.debug { "Mapped Entity: ${entity}" }
 
         val partEntity = try {
             partRepository.save(entity)
         } catch (e: Exception) {
-            throw ServiceException(ErrorCodesDomain.RELATION_NOT_VALID, e.message)
+            throw ServiceException(ErrorCodesDomain.RELATION_NOT_VALID, e.message ?: "Persisting failed", e)
         }
         logger.info { "Modified Part Entity: ${partEntity.createdAt?.toString()}, ${partEntity.label} - ${partEntity.partTypeRelations?.size}" }
         return mapper.map(partEntity)

--- a/src/main/kotlin/de/cyclingsir/cetrack/part/domain/PartTypeService.kt
+++ b/src/main/kotlin/de/cyclingsir/cetrack/part/domain/PartTypeService.kt
@@ -37,11 +37,18 @@ class PartTypeService(
     }
 
     fun modifyPartType(partTypeId: UUID, partType: DomainPartType): DomainPartType? {
+        if (partType.id != null && partType.id != partTypeId) {
+            throw ServiceException(ErrorCodesDomain.PART_TYPE_ID_MISMATCH)
+        }
+        if (!repository.existsById(partTypeId)) {
+            throw ServiceException(ErrorCodesDomain.PART_TYPE_NOT_FOUND)
+        }
+        val entity = mapper.map(partType)
+        entity.id = partTypeId
         val partTypeEntity = try {
-            assert(partTypeId == partType.id)
-            repository.save(mapper.map(partType))
+            repository.save(entity)
         } catch (e: Exception) {
-            throw ServiceException(ErrorCodesDomain.PART_TYPE_NOT_PERSISTED, e.message)
+            throw ServiceException(ErrorCodesDomain.PART_TYPE_NOT_PERSISTED, e.message ?: "Persisting failed", e)
         }
         return mapper.map(partTypeEntity)
     }

--- a/src/test/kotlin/de/cyclingsir/cetrack/bike/domain/BikeServiceTest.kt
+++ b/src/test/kotlin/de/cyclingsir/cetrack/bike/domain/BikeServiceTest.kt
@@ -1,0 +1,108 @@
+package de.cyclingsir.cetrack.bike.domain
+
+import de.cyclingsir.cetrack.bike.storage.BikeEntity
+import de.cyclingsir.cetrack.bike.storage.BikeRepository
+import de.cyclingsir.cetrack.bike.storage.BikeDomain2StorageMapper
+import de.cyclingsir.cetrack.common.errorhandling.ErrorCodesDomain
+import de.cyclingsir.cetrack.common.errorhandling.ServiceException
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+class BikeServiceTest {
+
+  companion object {
+    val UUID_BIKE_A = UUID.randomUUID()
+    val UUID_BIKE_B = UUID.randomUUID()
+  }
+
+  @MockK
+  private lateinit var repository: BikeRepository
+
+  @MockK
+  private lateinit var mapper: BikeDomain2StorageMapper
+
+  private lateinit var bikeService: BikeService
+
+  @BeforeEach
+  fun init() {
+    MockKAnnotations.init(this)
+    bikeService = BikeService(repository, mapper)
+  }
+
+  private fun bikeWith(model: String, id: UUID? = null) =
+    DomainBike(model = model, manufacturer = null, id = id, boughtAt = null, retiredAt = null, createdAt = null)
+
+  @Test
+  fun `modifyBike rejects when body id does not match path id`() {
+    val pathId = UUID_BIKE_A
+    val bike = bikeWith(model = "Tarmac", id = UUID_BIKE_B)
+
+    val ex = Assertions.assertThrows(ServiceException::class.java) {
+      bikeService.modifyBike(pathId, bike)
+    }
+    Assertions.assertEquals(ErrorCodesDomain.BIKE_ID_MISMATCH.code, ex.getError().code)
+    verify(exactly = 0) { repository.save(any()) }
+  }
+
+  @Test
+  fun `modifyBike returns not found when bike does not exist`() {
+    val pathId = UUID_BIKE_A
+    val bike = bikeWith(model = "Tarmac")
+
+    every { repository.existsById(pathId) } returns false
+
+    val ex = Assertions.assertThrows(ServiceException::class.java) {
+      bikeService.modifyBike(pathId, bike)
+    }
+    Assertions.assertEquals(ErrorCodesDomain.BIKE_NOT_FOUND.code, ex.getError().code)
+    verify(exactly = 0) { repository.save(any()) }
+  }
+
+  @Test
+  fun `modifyBike saves entity with path id when body id is null`() {
+    val pathId = UUID_BIKE_A
+    val bike = bikeWith(model = "Tarmac")
+    val mappedEntity = BikeEntity(id = null, model = "Tarmac")
+    val savedEntity = BikeEntity(id = pathId, model = "Tarmac")
+    val savedEntitySlot = slot<BikeEntity>()
+
+    every { repository.existsById(pathId) } returns true
+    every { mapper.map(bike) } returns mappedEntity
+    every { repository.save(capture(savedEntitySlot)) } returns savedEntity
+    every { mapper.map(savedEntity) } returns bikeWith(model = "Tarmac", id = pathId)
+
+    val result = bikeService.modifyBike(pathId, bike)
+
+    Assertions.assertEquals(pathId, savedEntitySlot.captured.id)
+    Assertions.assertEquals(pathId, result?.id)
+    verify(exactly = 1) { repository.save(any()) }
+  }
+
+  @Test
+  fun `modifyBike accepts matching body id and path id`() {
+    val pathId = UUID_BIKE_A
+    val bike = bikeWith(model = "Tarmac", id = pathId)
+    val mappedEntity = BikeEntity(id = pathId, model = "Tarmac")
+    val savedEntity = BikeEntity(id = pathId, model = "Tarmac")
+
+    every { repository.existsById(pathId) } returns true
+    every { mapper.map(bike) } returns mappedEntity
+    every { repository.save(any()) } returns savedEntity
+    every { mapper.map(savedEntity) } returns bikeWith(model = "Tarmac", id = pathId)
+
+    val result = bikeService.modifyBike(pathId, bike)
+
+    Assertions.assertEquals(pathId, result?.id)
+    verify(exactly = 1) { repository.save(any()) }
+  }
+}

--- a/src/test/kotlin/de/cyclingsir/cetrack/part/domain/PartServiceTest.kt
+++ b/src/test/kotlin/de/cyclingsir/cetrack/part/domain/PartServiceTest.kt
@@ -93,6 +93,79 @@ class PartServiceTest {
     boughtAt = null, retiredAt = null, partTypeRelations = emptyList(), createdAt = null)
 
   @Test
+  fun `modifyPart rejects when body id does not match path id`() {
+    val pathId = UUID_PART_A
+    val mismatchedBodyId = UUID_PART_B
+    val part = partWith(label = "Tire", model = null).copy(id = mismatchedBodyId)
+
+    val ex = Assertions.assertThrows(ServiceException::class.java) {
+      partService.modifyPart(pathId, part)
+    }
+    Assertions.assertEquals(ErrorCodesDomain.PART_ID_MISMATCH.code, ex.getError().code)
+    verify(exactly = 0) { partRepository.save(any()) }
+  }
+
+  @Test
+  fun `modifyPart returns not found when part does not exist even if body is unidentifiable`() {
+    val pathId = UUID_PART_A
+    val unidentifiablePart = partWith(label = null, model = null)
+
+    every { partRepository.existsById(pathId) } returns false
+
+    val ex = Assertions.assertThrows(ServiceException::class.java) {
+      partService.modifyPart(pathId, unidentifiablePart)
+    }
+    Assertions.assertEquals(ErrorCodesDomain.PART_NOT_FOUND.code, ex.getError().code)
+    verify(exactly = 0) { partRepository.save(any()) }
+  }
+
+  @Test
+  fun `modifyPart returns not found when part does not exist`() {
+    val pathId = UUID_PART_A
+    val part = partWith(label = "Tire", model = null)
+
+    every { partRepository.existsById(pathId) } returns false
+
+    val ex = Assertions.assertThrows(ServiceException::class.java) {
+      partService.modifyPart(pathId, part)
+    }
+    Assertions.assertEquals(ErrorCodesDomain.PART_NOT_FOUND.code, ex.getError().code)
+    verify(exactly = 0) { partRepository.save(any()) }
+  }
+
+  @Test
+  fun `modifyPart saves entity with path id when body id is null`() {
+    val pathId = UUID_PART_A
+    val part = partWith(label = "Tire", model = null)
+    val savedEntitySlot = slot<PartEntity>()
+    val savedEntity = PartEntity(id = pathId, label = "Tire", partTypeRelations = emptyList())
+
+    every { partRepository.existsById(pathId) } returns true
+    every { partRepository.save(capture(savedEntitySlot)) } returns savedEntity
+
+    val result = partService.modifyPart(pathId, part)
+
+    Assertions.assertEquals(pathId, savedEntitySlot.captured.id)
+    Assertions.assertEquals(pathId, result?.id)
+    verify(exactly = 1) { partRepository.save(any()) }
+  }
+
+  @Test
+  fun `modifyPart accepts matching body id and path id`() {
+    val pathId = UUID_PART_A
+    val part = partWith(label = "Tire", model = null).copy(id = pathId)
+    val savedEntity = PartEntity(id = pathId, label = "Tire", partTypeRelations = emptyList())
+
+    every { partRepository.existsById(pathId) } returns true
+    every { partRepository.save(any()) } returns savedEntity
+
+    val result = partService.modifyPart(pathId, part)
+
+    Assertions.assertEquals(pathId, result?.id)
+    verify(exactly = 1) { partRepository.save(any()) }
+  }
+
+  @Test
   fun `addPart rejects a part with neither label nor model`() {
     val ex = Assertions.assertThrows(ServiceException::class.java) {
       partService.addPart(partWith(label = "  ", model = null))

--- a/src/test/kotlin/de/cyclingsir/cetrack/part/domain/PartTypeServiceTest.kt
+++ b/src/test/kotlin/de/cyclingsir/cetrack/part/domain/PartTypeServiceTest.kt
@@ -1,0 +1,129 @@
+package de.cyclingsir.cetrack.part.domain
+
+import de.cyclingsir.cetrack.bike.domain.BikeService
+import de.cyclingsir.cetrack.bike.storage.BikeDomain2StorageMapper
+import de.cyclingsir.cetrack.common.errorhandling.ErrorCodesDomain
+import de.cyclingsir.cetrack.common.errorhandling.ServiceException
+import de.cyclingsir.cetrack.part.storage.PartDomain2StorageMapperImpl
+import de.cyclingsir.cetrack.part.storage.PartPartTypeRelationDomain2StorageMapperImpl
+import de.cyclingsir.cetrack.part.storage.PartStorageMapper
+import de.cyclingsir.cetrack.part.storage.PartTypeEntity
+import de.cyclingsir.cetrack.part.storage.PartTypeDomain2StorageMapperImpl
+import de.cyclingsir.cetrack.part.storage.PartTypeRepository
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+class PartTypeServiceTest {
+
+  companion object {
+    val UUID_PART_TYPE_A = UUID.randomUUID()
+    val UUID_PART_TYPE_B = UUID.randomUUID()
+    val UUID_BIKE = UUID.randomUUID()
+  }
+
+  @MockK
+  private lateinit var repository: PartTypeRepository
+
+  @MockK
+  private lateinit var bikeMapper: BikeDomain2StorageMapper
+
+  @MockK
+  private lateinit var bikeService: BikeService
+
+  private val partStorageMapper =
+    PartStorageMapper(PartDomain2StorageMapperImpl(), PartTypeDomain2StorageMapperImpl(),
+      PartPartTypeRelationDomain2StorageMapperImpl())
+
+  private lateinit var partTypeService: PartTypeService
+
+  @BeforeEach
+  fun init() {
+    MockKAnnotations.init(this)
+    partTypeService = PartTypeService(repository, partStorageMapper, bikeMapper, bikeService)
+  }
+
+  private fun partTypeWith(name: String, id: UUID? = null) =
+    DomainPartType(id = id, name = name, mandatory = false, partTypeRelations = emptyList(), bike = null, createdAt = null)
+
+  @Test
+  fun `modifyPartType rejects when body id does not match path id`() {
+    val pathId = UUID_PART_TYPE_A
+    val partType = partTypeWith(name = "Crank", id = UUID_PART_TYPE_B)
+
+    val ex = Assertions.assertThrows(ServiceException::class.java) {
+      partTypeService.modifyPartType(pathId, partType)
+    }
+    Assertions.assertEquals(ErrorCodesDomain.PART_TYPE_ID_MISMATCH.code, ex.getError().code)
+    verify(exactly = 0) { repository.save(any()) }
+  }
+
+  @Test
+  fun `modifyPartType returns not found when part type does not exist`() {
+    val pathId = UUID_PART_TYPE_A
+    val partType = partTypeWith(name = "Crank")
+
+    every { repository.existsById(pathId) } returns false
+
+    val ex = Assertions.assertThrows(ServiceException::class.java) {
+      partTypeService.modifyPartType(pathId, partType)
+    }
+    Assertions.assertEquals(ErrorCodesDomain.PART_TYPE_NOT_FOUND.code, ex.getError().code)
+    verify(exactly = 0) { repository.save(any()) }
+  }
+
+  @Test
+  fun `modifyPartType returns not found even when body id is missing and name is blank`() {
+    val pathId = UUID_PART_TYPE_A
+    val unidentifiablePartType = partTypeWith(name = "")
+
+    every { repository.existsById(pathId) } returns false
+
+    val ex = Assertions.assertThrows(ServiceException::class.java) {
+      partTypeService.modifyPartType(pathId, unidentifiablePartType)
+    }
+    Assertions.assertEquals(ErrorCodesDomain.PART_TYPE_NOT_FOUND.code, ex.getError().code)
+    verify(exactly = 0) { repository.save(any()) }
+  }
+
+  @Test
+  fun `modifyPartType saves entity with path id when body id is null`() {
+    val pathId = UUID_PART_TYPE_A
+    val partType = partTypeWith(name = "Crank")
+    val savedEntitySlot = slot<PartTypeEntity>()
+    val savedEntity = PartTypeEntity(id = pathId, name = "Crank", mandatory = false, partTypeRelations = emptyList())
+
+    every { repository.existsById(pathId) } returns true
+    every { repository.save(capture(savedEntitySlot)) } returns savedEntity
+
+    val result = partTypeService.modifyPartType(pathId, partType)
+
+    Assertions.assertEquals(pathId, savedEntitySlot.captured.id)
+    Assertions.assertEquals(pathId, result?.id)
+    verify(exactly = 1) { repository.save(any()) }
+  }
+
+  @Test
+  fun `modifyPartType accepts matching body id and path id`() {
+    val pathId = UUID_PART_TYPE_A
+    val partType = partTypeWith(name = "Crank", id = pathId)
+    val savedEntity = PartTypeEntity(id = pathId, name = "Crank", mandatory = false, partTypeRelations = emptyList())
+
+    every { repository.existsById(pathId) } returns true
+    every { repository.save(any()) } returns savedEntity
+
+    val result = partTypeService.modifyPartType(pathId, partType)
+
+    Assertions.assertEquals(pathId, result?.id)
+    verify(exactly = 1) { repository.save(any()) }
+  }
+}


### PR DESCRIPTION
Dead assert replaced with a real 400 guard (body id mismatch), blind upsert replaced with existsById check + 404, nullable e.message fixed with cause-preserving constructor. BIKE_NOT_FOUND corrected to 404. [Claude Code - model: claude-sonnet-4-6]