### PR TITLE
CE-0014 Guard delete methods against missing ids

### DIFF
--- a/api/bike-api.yaml
+++ b/api/bike-api.yaml
@@ -114,6 +114,8 @@ paths:
           description: Bike successfully deleted.
         '400':
           description: Bad Request
+        '404':
+          description: Not Found
         '500':
           description: Internal Server Error
 

--- a/api/parts-api.yaml
+++ b/api/parts-api.yaml
@@ -135,6 +135,8 @@ paths:
           description: Part successfully deleted.
         '400':
           description: Bad Request
+        '404':
+          description: Not Found
         '500':
           description: Internal Server Error
   /parts/{partId}/action/relate:
@@ -257,6 +259,8 @@ paths:
           description: PartType successfully deleted.
         '400':
           description: Bad Request
+        '404':
+          description: Not Found
         '500':
           description: Internal Server Error
   /partTypes/{partTypeId}/action/relate:

--- a/src/main/kotlin/de/cyclingsir/cetrack/bike/domain/BikeService.kt
+++ b/src/main/kotlin/de/cyclingsir/cetrack/bike/domain/BikeService.kt
@@ -56,6 +56,7 @@ class BikeService(private val repository: BikeRepository, private val mapper: Bi
     }
 
     fun deleteBike(bikeId: UUID) {
+        if (!repository.existsById(bikeId)) throw ServiceException(ErrorCodesDomain.BIKE_NOT_FOUND)
         try {
             repository.deleteById(bikeId)
         } catch (e: DataIntegrityViolationException) {

--- a/src/main/kotlin/de/cyclingsir/cetrack/part/domain/PartService.kt
+++ b/src/main/kotlin/de/cyclingsir/cetrack/part/domain/PartService.kt
@@ -105,6 +105,7 @@ final class PartService(
     }
 
     fun deletePart(partId: UUID) {
+        if (!partRepository.existsById(partId)) throw ServiceException(ErrorCodesDomain.PART_NOT_FOUND)
         try {
             partRepository.deleteById(partId)
         } catch (e: Exception) {

--- a/src/main/kotlin/de/cyclingsir/cetrack/part/domain/PartTypeService.kt
+++ b/src/main/kotlin/de/cyclingsir/cetrack/part/domain/PartTypeService.kt
@@ -54,6 +54,7 @@ class PartTypeService(
     }
 
     fun deletePartType(partTypeId: UUID) {
+        if (!repository.existsById(partTypeId)) throw ServiceException(ErrorCodesDomain.PART_TYPE_NOT_FOUND)
         try {
             repository.deleteById(partTypeId)
         } catch (e: Exception) {

--- a/src/test/kotlin/de/cyclingsir/cetrack/bike/domain/BikeServiceTest.kt
+++ b/src/test/kotlin/de/cyclingsir/cetrack/bike/domain/BikeServiceTest.kt
@@ -9,6 +9,8 @@ import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
+import io.mockk.just
+import io.mockk.Runs
 import io.mockk.slot
 import io.mockk.verify
 import org.junit.jupiter.api.Assertions
@@ -86,6 +88,16 @@ class BikeServiceTest {
     Assertions.assertEquals(pathId, savedEntitySlot.captured.id)
     Assertions.assertEquals(pathId, result?.id)
     verify(exactly = 1) { repository.save(any()) }
+  }
+
+  @Test
+  fun `deleteBike throws not found when bike does not exist`() {
+    val id = UUID_BIKE_A
+    every { repository.existsById(id) } returns false
+    every { repository.deleteById(id) } just Runs
+    val ex = Assertions.assertThrows(ServiceException::class.java) { bikeService.deleteBike(id) }
+    Assertions.assertEquals(ErrorCodesDomain.BIKE_NOT_FOUND.code, ex.getError().code)
+    verify(exactly = 0) { repository.deleteById(any()) }
   }
 
   @Test

--- a/src/test/kotlin/de/cyclingsir/cetrack/part/domain/PartServiceTest.kt
+++ b/src/test/kotlin/de/cyclingsir/cetrack/part/domain/PartServiceTest.kt
@@ -15,6 +15,8 @@ import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
+import io.mockk.just
+import io.mockk.Runs
 import io.mockk.slot
 import io.mockk.verify
 import org.junit.jupiter.api.Assertions
@@ -288,6 +290,16 @@ class PartServiceTest {
     Assertions.assertNotNull(persistedRelationEntityPartB)
     Assertions.assertNull(persistedRelationEntityPartB!!.validUntil)
 
+  }
+
+  @Test
+  fun `deletePart throws not found when part does not exist`() {
+    val id = UUID_PART_A
+    every { partRepository.existsById(id) } returns false
+    every { partRepository.deleteById(id) } just Runs
+    val ex = Assertions.assertThrows(ServiceException::class.java) { partService.deletePart(id) }
+    Assertions.assertEquals(ErrorCodesDomain.PART_NOT_FOUND.code, ex.getError().code)
+    verify(exactly = 0) { partRepository.deleteById(any()) }
   }
 
 }

--- a/src/test/kotlin/de/cyclingsir/cetrack/part/domain/PartTypeServiceTest.kt
+++ b/src/test/kotlin/de/cyclingsir/cetrack/part/domain/PartTypeServiceTest.kt
@@ -14,6 +14,8 @@ import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
+import io.mockk.just
+import io.mockk.Runs
 import io.mockk.slot
 import io.mockk.verify
 import org.junit.jupiter.api.Assertions
@@ -110,6 +112,16 @@ class PartTypeServiceTest {
     Assertions.assertEquals(pathId, savedEntitySlot.captured.id)
     Assertions.assertEquals(pathId, result?.id)
     verify(exactly = 1) { repository.save(any()) }
+  }
+
+  @Test
+  fun `deletePartType throws not found when part type does not exist`() {
+    val id = UUID_PART_TYPE_A
+    every { repository.existsById(id) } returns false
+    every { repository.deleteById(id) } just Runs
+    val ex = Assertions.assertThrows(ServiceException::class.java) { partTypeService.deletePartType(id) }
+    Assertions.assertEquals(ErrorCodesDomain.PART_TYPE_NOT_FOUND.code, ex.getError().code)
+    verify(exactly = 0) { repository.deleteById(any()) }
   }
 
   @Test


### PR DESCRIPTION
JPA deleteById is a silent no-op when the id doesn't exist, causing DELETE endpoints to return 200 for non-existent resources. Add an existsById guard before deleteById in BikeService, PartService and PartTypeService, throwing ServiceException(*_NOT_FOUND) which CentralExceptionHandler maps to 404. OpenAPI specs updated with 404 response on all three delete operations. [Claude Code - model: claude-sonnet-4-6]