### PR TITLE
CE-0018 Narrow catch in deletePart/deletePartType to distinguish FK e…

### DIFF
--- a/src/main/kotlin/de/cyclingsir/cetrack/common/errorhandling/ErrorCodesDomain.kt
+++ b/src/main/kotlin/de/cyclingsir/cetrack/common/errorhandling/ErrorCodesDomain.kt
@@ -15,6 +15,8 @@ enum class ErrorCodesDomain(
     PART_PRICE_CURRENCY_MISMATCH(104, 400, "Purchase price and currency code must be provided together"),
     PART_ID_MISMATCH(105, 400, "Path id does not match the part id in the body"),
     PART_TYPE_ID_MISMATCH(106, 400, "Path id does not match the part type id in the body"),
+    PART_HAS_FOREIGN_KEY_CONSTRAINT(107, 400, "Part can't be deleted."),
+    PART_TYPE_HAS_FOREIGN_KEY_CONSTRAINT(108, 400, "PartType can't be deleted."),
 
     RELATION_NOT_VALID(200, 400, "Relation not valid"),
 

--- a/src/main/kotlin/de/cyclingsir/cetrack/part/domain/PartService.kt
+++ b/src/main/kotlin/de/cyclingsir/cetrack/part/domain/PartService.kt
@@ -1,7 +1,9 @@
 package de.cyclingsir.cetrack.part.domain
 
 import de.cyclingsir.cetrack.common.errorhandling.ErrorCodesDomain
+import de.cyclingsir.cetrack.common.errorhandling.ErrorCodesService
 import de.cyclingsir.cetrack.common.errorhandling.ServiceException
+import org.springframework.dao.DataIntegrityViolationException
 import de.cyclingsir.cetrack.part.storage.PartEntity
 import de.cyclingsir.cetrack.part.storage.PartPartTypeRelationEntity
 import de.cyclingsir.cetrack.part.storage.PartPartTypeRelationRepository
@@ -108,8 +110,11 @@ final class PartService(
         if (!partRepository.existsById(partId)) throw ServiceException(ErrorCodesDomain.PART_NOT_FOUND)
         try {
             partRepository.deleteById(partId)
+        } catch (e: DataIntegrityViolationException) {
+            throw ServiceException(ErrorCodesDomain.PART_HAS_FOREIGN_KEY_CONSTRAINT,
+                "Part is referenced by a relation. Remove it first.")
         } catch (e: Exception) {
-            throw ServiceException(ErrorCodesDomain.PART_NOT_FOUND, e.message)
+            throw ServiceException(ErrorCodesService.INTERNAL_SERVER_ERROR)
         }
     }
 

--- a/src/main/kotlin/de/cyclingsir/cetrack/part/domain/PartTypeService.kt
+++ b/src/main/kotlin/de/cyclingsir/cetrack/part/domain/PartTypeService.kt
@@ -3,7 +3,9 @@ package de.cyclingsir.cetrack.part.domain
 import de.cyclingsir.cetrack.bike.domain.BikeService
 import de.cyclingsir.cetrack.bike.storage.BikeDomain2StorageMapper
 import de.cyclingsir.cetrack.common.errorhandling.ErrorCodesDomain
+import de.cyclingsir.cetrack.common.errorhandling.ErrorCodesService
 import de.cyclingsir.cetrack.common.errorhandling.ServiceException
+import org.springframework.dao.DataIntegrityViolationException
 import de.cyclingsir.cetrack.part.storage.PartStorageMapper
 import de.cyclingsir.cetrack.part.storage.PartTypeEntity
 import de.cyclingsir.cetrack.part.storage.PartTypeRepository
@@ -57,8 +59,11 @@ class PartTypeService(
         if (!repository.existsById(partTypeId)) throw ServiceException(ErrorCodesDomain.PART_TYPE_NOT_FOUND)
         try {
             repository.deleteById(partTypeId)
+        } catch (e: DataIntegrityViolationException) {
+            throw ServiceException(ErrorCodesDomain.PART_TYPE_HAS_FOREIGN_KEY_CONSTRAINT,
+                "PartType is referenced by a part relation. Remove it first.")
         } catch (e: Exception) {
-            throw ServiceException(ErrorCodesDomain.PART_TYPE_NOT_FOUND, e.message)
+            throw ServiceException(ErrorCodesService.INTERNAL_SERVER_ERROR)
         }
     }
 

--- a/src/test/kotlin/de/cyclingsir/cetrack/part/domain/PartServiceTest.kt
+++ b/src/test/kotlin/de/cyclingsir/cetrack/part/domain/PartServiceTest.kt
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.dao.DataIntegrityViolationException
 import java.time.Instant
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
@@ -300,6 +301,16 @@ class PartServiceTest {
     val ex = Assertions.assertThrows(ServiceException::class.java) { partService.deletePart(id) }
     Assertions.assertEquals(ErrorCodesDomain.PART_NOT_FOUND.code, ex.getError().code)
     verify(exactly = 0) { partRepository.deleteById(any()) }
+  }
+
+  @Test
+  fun `deletePart maps constraint violation to FK error not not-found`() {
+    val id = UUID_PART_A
+    every { partRepository.existsById(id) } returns true
+    every { partRepository.deleteById(id) } throws DataIntegrityViolationException("FK_PART_RELATION")
+    val ex = Assertions.assertThrows(ServiceException::class.java) { partService.deletePart(id) }
+    Assertions.assertEquals(ErrorCodesDomain.PART_HAS_FOREIGN_KEY_CONSTRAINT.code, ex.getError().code)
+    Assertions.assertEquals(400, ex.getError().httpStatus)
   }
 
 }

--- a/src/test/kotlin/de/cyclingsir/cetrack/part/domain/PartTypeServiceTest.kt
+++ b/src/test/kotlin/de/cyclingsir/cetrack/part/domain/PartTypeServiceTest.kt
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.dao.DataIntegrityViolationException
 import java.util.UUID
 
 @ExtendWith(MockKExtension::class)
@@ -122,6 +123,16 @@ class PartTypeServiceTest {
     val ex = Assertions.assertThrows(ServiceException::class.java) { partTypeService.deletePartType(id) }
     Assertions.assertEquals(ErrorCodesDomain.PART_TYPE_NOT_FOUND.code, ex.getError().code)
     verify(exactly = 0) { repository.deleteById(any()) }
+  }
+
+  @Test
+  fun `deletePartType maps constraint violation to FK error not not-found`() {
+    val id = UUID_PART_TYPE_A
+    every { repository.existsById(id) } returns true
+    every { repository.deleteById(id) } throws DataIntegrityViolationException("FK_PART_TYPE_RELATION")
+    val ex = Assertions.assertThrows(ServiceException::class.java) { partTypeService.deletePartType(id) }
+    Assertions.assertEquals(ErrorCodesDomain.PART_TYPE_HAS_FOREIGN_KEY_CONSTRAINT.code, ex.getError().code)
+    Assertions.assertEquals(400, ex.getError().httpStatus)
   }
 
   @Test


### PR DESCRIPTION
…rrors from not-found

DataIntegrityViolationException during deleteById is now mapped to PART_HAS_FOREIGN_KEY_CONSTRAINT / PART_TYPE_HAS_FOREIGN_KEY_CONSTRAINT (400) instead of *_NOT_FOUND (404). Any other exception falls through to INTERNAL_SERVER_ERROR (500).
[Claude Code - model: claude-sonnet-4-6]