### PR TITLE
CE-0021 Differentiate data vs technical errors on repository.save()

### DIFF
--- a/api/parts-api.yaml
+++ b/api/parts-api.yaml
@@ -164,6 +164,8 @@ paths:
           description: Bad Request
         '404':
           description: Not Found
+        '500':
+          description: Internal Server Error
   /partTypes:
     get:
       operationId: getPartTypes

--- a/src/main/kotlin/de/cyclingsir/cetrack/bike/domain/BikeService.kt
+++ b/src/main/kotlin/de/cyclingsir/cetrack/bike/domain/BikeService.kt
@@ -49,6 +49,8 @@ class BikeService(private val repository: BikeRepository, private val mapper: Bi
         entity.id = bikeId
         val bikeEntity = try {
             repository.save(entity)
+        } catch (e: DataIntegrityViolationException) {
+            throw ServiceException(ErrorCodesDomain.BIKE_DATA_INVALID, e.message ?: "Invalid bike data", e)
         } catch (e: Exception) {
             throw ServiceException(ErrorCodesService.INTERNAL_SERVER_ERROR, e.message ?: "Persisting failed", e)
         }

--- a/src/main/kotlin/de/cyclingsir/cetrack/common/errorhandling/ErrorCodesDomain.kt
+++ b/src/main/kotlin/de/cyclingsir/cetrack/common/errorhandling/ErrorCodesDomain.kt
@@ -10,20 +10,21 @@ enum class ErrorCodesDomain(
 ) : ServiceError {
     PART_NOT_FOUND(100, 404, "Part not found"),
     PART_TYPE_NOT_FOUND(101, 404, "PartType not found"),
-    PART_TYPE_NOT_PERSISTED(102, 500, "PartType could not be persisted"),
+    PART_TYPE_DATA_INVALID(102, 400, "PartType data violates a constraint"),
     PART_NOT_IDENTIFIABLE(103, 400, "A part must have at least a label or a model"),
     PART_PRICE_CURRENCY_MISMATCH(104, 400, "Purchase price and currency code must be provided together"),
     PART_ID_MISMATCH(105, 400, "Path id does not match the part id in the body"),
     PART_TYPE_ID_MISMATCH(106, 400, "Path id does not match the part type id in the body"),
     PART_HAS_FOREIGN_KEY_CONSTRAINT(107, 400, "Part can't be deleted."),
     PART_TYPE_HAS_FOREIGN_KEY_CONSTRAINT(108, 400, "PartType can't be deleted."),
+    PART_DATA_INVALID(109, 400, "Part data violates a constraint"),
 
     RELATION_NOT_VALID(200, 400, "Relation not valid"),
 
     PREVIOUS_RELATION_NOT_FOUND(201, 400, "Previous relation to finalize not found"),
 
     BIKE_NOT_FOUND(300, 404, "Bike not found"),
-    BIKE_NOT_PERSISTED(301, 404, "Unable to persist bike"),
+    BIKE_DATA_INVALID(301, 400, "Bike data violates a constraint"),
     BIKE_HAS_FOREIGN_KEY_CONSTRAINT(302, 400, "Bike can't be deleted."),
     BIKE_ID_MISMATCH(303, 400, "Path id does not match the bike id in the body"),
 

--- a/src/main/kotlin/de/cyclingsir/cetrack/part/domain/PartService.kt
+++ b/src/main/kotlin/de/cyclingsir/cetrack/part/domain/PartService.kt
@@ -99,8 +99,10 @@ final class PartService(
 
         val partEntity = try {
             partRepository.save(entity)
+        } catch (e: DataIntegrityViolationException) {
+            throw ServiceException(ErrorCodesDomain.PART_DATA_INVALID, e.message ?: "Invalid part data", e)
         } catch (e: Exception) {
-            throw ServiceException(ErrorCodesDomain.RELATION_NOT_VALID, e.message ?: "Persisting failed", e)
+            throw ServiceException(ErrorCodesService.INTERNAL_SERVER_ERROR, e.message ?: "Persisting failed", e)
         }
         logger.info { "Modified Part Entity: ${partEntity.createdAt?.toString()}, ${partEntity.label} - ${partEntity.partTypeRelations?.size}" }
         return mapper.map(partEntity)
@@ -232,9 +234,12 @@ final class PartService(
                     relation.validUntil = validUntil
                     partParTypRelationRepository.save(relation)
                 }
-            } catch (ex: Exception) {
+            } catch (ex: DataIntegrityViolationException) {
                 logger.debug {"Persisting failed: ${ex.message}"}
                 throw ServiceException(ErrorCodesDomain.RELATION_NOT_VALID, ex)
+            } catch (ex: Exception) {
+                logger.debug {"Persisting failed: ${ex.message}"}
+                throw ServiceException(ErrorCodesService.INTERNAL_SERVER_ERROR, ex.message ?: "Persisting failed", ex)
             }
         }
     }

--- a/src/main/kotlin/de/cyclingsir/cetrack/part/domain/PartTypeService.kt
+++ b/src/main/kotlin/de/cyclingsir/cetrack/part/domain/PartTypeService.kt
@@ -49,8 +49,10 @@ class PartTypeService(
         entity.id = partTypeId
         val partTypeEntity = try {
             repository.save(entity)
+        } catch (e: DataIntegrityViolationException) {
+            throw ServiceException(ErrorCodesDomain.PART_TYPE_DATA_INVALID, e.message ?: "Invalid part type data", e)
         } catch (e: Exception) {
-            throw ServiceException(ErrorCodesDomain.PART_TYPE_NOT_PERSISTED, e.message ?: "Persisting failed", e)
+            throw ServiceException(ErrorCodesService.INTERNAL_SERVER_ERROR, e.message ?: "Persisting failed", e)
         }
         return mapper.map(partTypeEntity)
     }

--- a/src/test/kotlin/de/cyclingsir/cetrack/bike/domain/BikeServiceTest.kt
+++ b/src/test/kotlin/de/cyclingsir/cetrack/bike/domain/BikeServiceTest.kt
@@ -13,6 +13,7 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.just
 import io.mockk.Runs
+import org.springframework.dao.DataIntegrityViolationException
 import io.mockk.slot
 import io.mockk.verify
 import net.bytebuddy.matcher.ElementMatchers.any
@@ -135,6 +136,22 @@ class BikeServiceTest {
     }
     Assertions.assertEquals(ErrorCodesService.INTERNAL_SERVER_ERROR.code, ex.getError().code)
     Assertions.assertEquals(500, ex.getError().httpStatus)
+  }
+
+  @Test
+  fun `modifyBike maps constraint violation to data invalid not server error`() {
+    val pathId = UUID_BIKE_A
+    val bike = bikeWith(model = "Daytona", id = pathId)
+    val savedEntity = BikeEntity(id = pathId, model = "Daytona")
+    every { repository.existsById(pathId) } returns true
+    every { mapper.map(bike) } returns savedEntity
+    every { repository.save(any()) } throws DataIntegrityViolationException("CONSTRAINT_VIOLATION")
+
+    val ex = Assertions.assertThrows(ServiceException::class.java) {
+      bikeService.modifyBike(pathId, bike)
+    }
+    Assertions.assertEquals(ErrorCodesDomain.BIKE_DATA_INVALID.code, ex.getError().code)
+    Assertions.assertEquals(400, ex.getError().httpStatus)
   }
 
 }

--- a/src/test/kotlin/de/cyclingsir/cetrack/part/domain/PartServiceTest.kt
+++ b/src/test/kotlin/de/cyclingsir/cetrack/part/domain/PartServiceTest.kt
@@ -2,6 +2,7 @@ package de.cyclingsir.cetrack.part.domain;
 
 import de.cyclingsir.cetrack.bike.domain.DomainBike
 import de.cyclingsir.cetrack.common.errorhandling.ErrorCodesDomain
+import de.cyclingsir.cetrack.common.errorhandling.ErrorCodesService
 import de.cyclingsir.cetrack.common.errorhandling.ServiceException
 import de.cyclingsir.cetrack.part.storage.PartDomain2StorageMapperImpl
 import de.cyclingsir.cetrack.part.storage.PartEntity
@@ -291,6 +292,76 @@ class PartServiceTest {
     Assertions.assertNotNull(persistedRelationEntityPartB)
     Assertions.assertNull(persistedRelationEntityPartB!!.validUntil)
 
+  }
+
+  @Test
+  fun `modifyPart maps constraint violation to data invalid not server error`() {
+    val pathId = UUID_PART_A
+    val part = partWith(label = "Tire", model = null)
+    val existingEntity = PartEntity(pathId, "A", emptyList())
+    every { partRepository.findById(pathId) } returns Optional.of(existingEntity)
+    every { partRepository.save(any()) } throws DataIntegrityViolationException("CONSTRAINT_VIOLATION")
+
+    val ex = Assertions.assertThrows(ServiceException::class.java) {
+      partService.modifyPart(pathId, part)
+    }
+    Assertions.assertEquals(ErrorCodesDomain.PART_DATA_INVALID.code, ex.getError().code)
+    Assertions.assertEquals(400, ex.getError().httpStatus)
+  }
+
+  @Test
+  fun `modifyPart maps technical failure to server error`() {
+    val pathId = UUID_PART_A
+    val part = partWith(label = "Tire", model = null)
+    val existingEntity = PartEntity(pathId, "A", emptyList())
+    every { partRepository.findById(pathId) } returns Optional.of(existingEntity)
+    every { partRepository.save(any()) } throws RuntimeException("db down")
+
+    val ex = Assertions.assertThrows(ServiceException::class.java) {
+      partService.modifyPart(pathId, part)
+    }
+    Assertions.assertEquals(ErrorCodesService.INTERNAL_SERVER_ERROR.code, ex.getError().code)
+    Assertions.assertEquals(500, ex.getError().httpStatus)
+  }
+
+  @Test
+  fun `createPartPartTypeRelation maps relation constraint violation to relation not valid`() {
+    val validFrom = OffsetDateTime.now()
+    val relation = DomainPartPartTypeRelation(UUID_PART_B, UUID_PART_TYPE_CRANK, validFrom, null, domainPartA, domainPartTypeCrank)
+    val existingOpenRelation = partStorageMapper.map(
+      DomainPartPartTypeRelation(UUID_PART_A, UUID_PART_TYPE_CRANK, validFrom.minus(10, ChronoUnit.DAYS), null, domainPartA, domainPartTypeCrank))
+
+    every { relationRepository.countByPartId(UUID_PART_B) } returns 0
+    every { relationRepository.countByPartIdAndValidUntilIsNull(UUID_PART_B) } returns 0
+    every { relationRepository.countByPartTypeIdAndValidUntilIsNull(UUID_PART_TYPE_CRANK) } returns 1
+    every { relationRepository.findFirstByPartTypeIdAndValidUntilIsNull(UUID_PART_TYPE_CRANK) } returns existingOpenRelation
+    every { relationRepository.save(any()) } throws DataIntegrityViolationException("CONSTRAINT_VIOLATION")
+
+    val ex = Assertions.assertThrows(ServiceException::class.java) {
+      partService.createPartPartTypeRelation(relation)
+    }
+    Assertions.assertEquals(ErrorCodesDomain.RELATION_NOT_VALID.code, ex.getError().code)
+    Assertions.assertEquals(400, ex.getError().httpStatus)
+  }
+
+  @Test
+  fun `createPartPartTypeRelation maps technical failure when modifying relation to server error`() {
+    val validFrom = OffsetDateTime.now()
+    val relation = DomainPartPartTypeRelation(UUID_PART_B, UUID_PART_TYPE_CRANK, validFrom, null, domainPartA, domainPartTypeCrank)
+    val existingOpenRelation = partStorageMapper.map(
+      DomainPartPartTypeRelation(UUID_PART_A, UUID_PART_TYPE_CRANK, validFrom.minus(10, ChronoUnit.DAYS), null, domainPartA, domainPartTypeCrank))
+
+    every { relationRepository.countByPartId(UUID_PART_B) } returns 0
+    every { relationRepository.countByPartIdAndValidUntilIsNull(UUID_PART_B) } returns 0
+    every { relationRepository.countByPartTypeIdAndValidUntilIsNull(UUID_PART_TYPE_CRANK) } returns 1
+    every { relationRepository.findFirstByPartTypeIdAndValidUntilIsNull(UUID_PART_TYPE_CRANK) } returns existingOpenRelation
+    every { relationRepository.save(any()) } throws RuntimeException("db down")
+
+    val ex = Assertions.assertThrows(ServiceException::class.java) {
+      partService.createPartPartTypeRelation(relation)
+    }
+    Assertions.assertEquals(ErrorCodesService.INTERNAL_SERVER_ERROR.code, ex.getError().code)
+    Assertions.assertEquals(500, ex.getError().httpStatus)
   }
 
   @Test

--- a/src/test/kotlin/de/cyclingsir/cetrack/part/domain/PartTypeServiceTest.kt
+++ b/src/test/kotlin/de/cyclingsir/cetrack/part/domain/PartTypeServiceTest.kt
@@ -3,6 +3,7 @@ package de.cyclingsir.cetrack.part.domain
 import de.cyclingsir.cetrack.bike.domain.BikeService
 import de.cyclingsir.cetrack.bike.storage.BikeDomain2StorageMapper
 import de.cyclingsir.cetrack.common.errorhandling.ErrorCodesDomain
+import de.cyclingsir.cetrack.common.errorhandling.ErrorCodesService
 import de.cyclingsir.cetrack.common.errorhandling.ServiceException
 import de.cyclingsir.cetrack.part.storage.PartDomain2StorageMapperImpl
 import de.cyclingsir.cetrack.part.storage.PartPartTypeRelationDomain2StorageMapperImpl
@@ -136,7 +137,7 @@ class PartTypeServiceTest {
   }
 
   @Test
-  fun `modifyPartType maps persistence failure to server error not not-found`() {
+  fun `modifyPartType maps technical failure to server error`() {
     val pathId = UUID_PART_TYPE_A
     val partType = partTypeWith(name = "Crank")
     every { repository.existsById(pathId) } returns true
@@ -145,8 +146,22 @@ class PartTypeServiceTest {
     val ex = Assertions.assertThrows(ServiceException::class.java) {
       partTypeService.modifyPartType(pathId, partType)
     }
-    Assertions.assertEquals(ErrorCodesDomain.PART_TYPE_NOT_PERSISTED.code, ex.getError().code)
+    Assertions.assertEquals(ErrorCodesService.INTERNAL_SERVER_ERROR.code, ex.getError().code)
     Assertions.assertEquals(500, ex.getError().httpStatus)
+  }
+
+  @Test
+  fun `modifyPartType maps constraint violation to data invalid not server error`() {
+    val pathId = UUID_PART_TYPE_A
+    val partType = partTypeWith(name = "Crank")
+    every { repository.existsById(pathId) } returns true
+    every { repository.save(any()) } throws DataIntegrityViolationException("CONSTRAINT_VIOLATION")
+
+    val ex = Assertions.assertThrows(ServiceException::class.java) {
+      partTypeService.modifyPartType(pathId, partType)
+    }
+    Assertions.assertEquals(ErrorCodesDomain.PART_TYPE_DATA_INVALID.code, ex.getError().code)
+    Assertions.assertEquals(400, ex.getError().httpStatus)
   }
 
   @Test


### PR DESCRIPTION
All four save sites (modifyPart, modifyPartType, modifyBike, modifyRelation) now catch DataIntegrityViolationException → dedicated domain 400 code and generic Exception → INTERNAL_SERVER_ERROR (500), mirroring the existing delete* pattern. Removes orphaned PART_TYPE_NOT_PERSISTED and BIKE_NOT_PERSISTED; adds PART_DATA_INVALID, PART_TYPE_DATA_INVALID, BIKE_DATA_INVALID. OpenAPI spec gains 500 on relatePartToPartType which can now surface a technical error. [Claude Code - model: claude-sonnet-4-6]