### PR TITLE
CE-0015 Close TOCTOU gap in modifyPart/Bike/PartType

### DIFF
--- a/src/main/kotlin/de/cyclingsir/cetrack/bike/domain/BikeService.kt
+++ b/src/main/kotlin/de/cyclingsir/cetrack/bike/domain/BikeService.kt
@@ -9,6 +9,7 @@ import de.cyclingsir.cetrack.common.errorhandling.ServiceException
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
 
 /**
@@ -38,17 +39,20 @@ class BikeService(private val repository: BikeRepository, private val mapper: Bi
         return bikeEntities.map(mapper::map)
     }
 
+    @Transactional
     fun modifyBike(bikeId: UUID, bike: DomainBike): DomainBike? {
         if (bike.id != null && bike.id != bikeId) {
             throw ServiceException(ErrorCodesDomain.BIKE_ID_MISMATCH)
         }
-        if (!repository.existsById(bikeId)) {
-            throw ServiceException(ErrorCodesDomain.BIKE_NOT_FOUND)
-        }
-        val entity = mapper.map(bike)
-        entity.id = bikeId
+        val existing = repository.findById(bikeId)
+            .orElseThrow { ServiceException(ErrorCodesDomain.BIKE_NOT_FOUND) }
+        val incoming = mapper.map(bike)
+        existing.model = incoming.model
+        existing.manufacturer = incoming.manufacturer
+        existing.boughtAt = incoming.boughtAt
+        existing.retiredAt = incoming.retiredAt
         val bikeEntity = try {
-            repository.save(entity)
+            repository.saveAndFlush(existing)
         } catch (e: DataIntegrityViolationException) {
             throw ServiceException(ErrorCodesDomain.BIKE_DATA_INVALID, e.message ?: "Invalid bike data", e)
         } catch (e: Exception) {

--- a/src/main/kotlin/de/cyclingsir/cetrack/part/domain/PartService.kt
+++ b/src/main/kotlin/de/cyclingsir/cetrack/part/domain/PartService.kt
@@ -4,6 +4,7 @@ import de.cyclingsir.cetrack.common.errorhandling.ErrorCodesDomain
 import de.cyclingsir.cetrack.common.errorhandling.ErrorCodesService
 import de.cyclingsir.cetrack.common.errorhandling.ServiceException
 import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.transaction.annotation.Transactional
 import de.cyclingsir.cetrack.part.storage.PartEntity
 import de.cyclingsir.cetrack.part.storage.PartPartTypeRelationEntity
 import de.cyclingsir.cetrack.part.storage.PartPartTypeRelationRepository
@@ -22,7 +23,7 @@ import java.util.UUID
 private val logger = KotlinLogging.logger {}
 
 @Service
-final class PartService(
+class PartService(
     private val partRepository: PartRepository,
     private val partParTypRelationRepository: PartPartTypeRelationRepository,
     private val mapper: PartStorageMapper
@@ -82,6 +83,7 @@ final class PartService(
         }
     }
 
+    @Transactional
     fun modifyPart(partId: UUID, part: DomainPart): DomainPart? {
         logger.debug { "Modify Part for part ${part} was called!" }
         if (part.id != null && part.id != partId) {
@@ -92,13 +94,21 @@ final class PartService(
         requireIdentifiable(part)
         requirePricePair(part)
         logger.debug { "DomainPart: ${part}" }
-        val entity = mapper.map(part)
-        entity.id = partId
-        entity.partTypeRelations = existing.partTypeRelations
-        logger.debug { "Mapped Entity: ${entity}" }
+        val incoming = mapper.map(part)
+        existing.label = incoming.label
+        existing.manufacturer = incoming.manufacturer
+        existing.model = incoming.model
+        existing.serialNumber = incoming.serialNumber
+        existing.vendor = incoming.vendor
+        existing.purchasePrice = incoming.purchasePrice
+        existing.purchasePriceCurrency = incoming.purchasePriceCurrency
+        existing.firstUsedDate = incoming.firstUsedDate
+        existing.boughtAt = incoming.boughtAt
+        existing.retiredAt = incoming.retiredAt
+        logger.debug { "Mapped Entity: ${existing}" }
 
         val partEntity = try {
-            partRepository.save(entity)
+            partRepository.saveAndFlush(existing)
         } catch (e: DataIntegrityViolationException) {
             throw ServiceException(ErrorCodesDomain.PART_DATA_INVALID, e.message ?: "Invalid part data", e)
         } catch (e: Exception) {

--- a/src/main/kotlin/de/cyclingsir/cetrack/part/domain/PartTypeService.kt
+++ b/src/main/kotlin/de/cyclingsir/cetrack/part/domain/PartTypeService.kt
@@ -11,6 +11,7 @@ import de.cyclingsir.cetrack.part.storage.PartTypeEntity
 import de.cyclingsir.cetrack.part.storage.PartTypeRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
 
 /**
@@ -38,17 +39,19 @@ class PartTypeService(
         return partTypeEntities.map(mapper::map)
     }
 
+    @Transactional
     fun modifyPartType(partTypeId: UUID, partType: DomainPartType): DomainPartType? {
         if (partType.id != null && partType.id != partTypeId) {
             throw ServiceException(ErrorCodesDomain.PART_TYPE_ID_MISMATCH)
         }
-        if (!repository.existsById(partTypeId)) {
-            throw ServiceException(ErrorCodesDomain.PART_TYPE_NOT_FOUND)
-        }
-        val entity = mapper.map(partType)
-        entity.id = partTypeId
+        val existing = repository.findById(partTypeId)
+            .orElseThrow { ServiceException(ErrorCodesDomain.PART_TYPE_NOT_FOUND) }
+        val incoming = mapper.map(partType)
+        existing.name = incoming.name
+        existing.mandatory = incoming.mandatory
+        existing.bike = incoming.bike
         val partTypeEntity = try {
-            repository.save(entity)
+            repository.saveAndFlush(existing)
         } catch (e: DataIntegrityViolationException) {
             throw ServiceException(ErrorCodesDomain.PART_TYPE_DATA_INVALID, e.message ?: "Invalid part type data", e)
         } catch (e: Exception) {

--- a/src/test/kotlin/de/cyclingsir/cetrack/bike/domain/BikeServiceTest.kt
+++ b/src/test/kotlin/de/cyclingsir/cetrack/bike/domain/BikeServiceTest.kt
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import java.util.Optional
 import java.util.UUID
 
 @ExtendWith(MockKExtension::class)
@@ -65,33 +66,35 @@ class BikeServiceTest {
     val pathId = UUID_BIKE_A
     val bike = bikeWith(model = "Tarmac")
 
-    every { repository.existsById(pathId) } returns false
+    every { repository.findById(pathId) } returns Optional.empty()
 
     val ex = Assertions.assertThrows(ServiceException::class.java) {
       bikeService.modifyBike(pathId, bike)
     }
     Assertions.assertEquals(ErrorCodesDomain.BIKE_NOT_FOUND.code, ex.getError().code)
-    verify(exactly = 0) { repository.save(any()) }
+    verify(exactly = 0) { repository.saveAndFlush(any()) }
   }
 
   @Test
   fun `modifyBike saves entity with path id when body id is null`() {
     val pathId = UUID_BIKE_A
     val bike = bikeWith(model = "Tarmac")
+    val existingEntity = BikeEntity(id = pathId, model = "OldModel")
     val mappedEntity = BikeEntity(id = null, model = "Tarmac")
     val savedEntity = BikeEntity(id = pathId, model = "Tarmac")
     val savedEntitySlot = slot<BikeEntity>()
 
-    every { repository.existsById(pathId) } returns true
+    every { repository.findById(pathId) } returns Optional.of(existingEntity)
     every { mapper.map(bike) } returns mappedEntity
-    every { repository.save(capture(savedEntitySlot)) } returns savedEntity
+    every { repository.saveAndFlush(capture(savedEntitySlot)) } returns savedEntity
     every { mapper.map(savedEntity) } returns bikeWith(model = "Tarmac", id = pathId)
 
     val result = bikeService.modifyBike(pathId, bike)
 
+    Assertions.assertSame(existingEntity, savedEntitySlot.captured)
     Assertions.assertEquals(pathId, savedEntitySlot.captured.id)
     Assertions.assertEquals(pathId, result?.id)
-    verify(exactly = 1) { repository.save(any()) }
+    verify(exactly = 1) { repository.saveAndFlush(any()) }
   }
 
   @Test
@@ -108,28 +111,30 @@ class BikeServiceTest {
   fun `modifyBike accepts matching body id and path id`() {
     val pathId = UUID_BIKE_A
     val bike = bikeWith(model = "Tarmac", id = pathId)
+    val existingEntity = BikeEntity(id = pathId, model = "OldModel")
     val mappedEntity = BikeEntity(id = pathId, model = "Tarmac")
     val savedEntity = BikeEntity(id = pathId, model = "Tarmac")
 
-    every { repository.existsById(pathId) } returns true
+    every { repository.findById(pathId) } returns Optional.of(existingEntity)
     every { mapper.map(bike) } returns mappedEntity
-    every { repository.save(any()) } returns savedEntity
+    every { repository.saveAndFlush(any()) } returns savedEntity
     every { mapper.map(savedEntity) } returns bikeWith(model = "Tarmac", id = pathId)
 
     val result = bikeService.modifyBike(pathId, bike)
 
     Assertions.assertEquals(pathId, result?.id)
-    verify(exactly = 1) { repository.save(any()) }
+    verify(exactly = 1) { repository.saveAndFlush(any()) }
   }
 
   @Test
   fun `modifyBike maps technical failure to server error not not-found`() {
     val pathId = UUID_BIKE_A
     val bike = bikeWith(model = "Daytona", id = pathId)
-    val savedEntity = BikeEntity(id = pathId, model = "Daytona")
-    every { repository.existsById(pathId) } returns true
-    every { mapper.map(bike) } returns savedEntity
-    every { repository.save(any()) } throws RuntimeException("db down")
+    val existingEntity = BikeEntity(id = pathId, model = "OldModel")
+    val mappedEntity = BikeEntity(id = pathId, model = "Daytona")
+    every { repository.findById(pathId) } returns Optional.of(existingEntity)
+    every { mapper.map(bike) } returns mappedEntity
+    every { repository.saveAndFlush(any()) } throws RuntimeException("db down")
 
     val ex = Assertions.assertThrows(ServiceException::class.java) {
       bikeService.modifyBike(pathId, bike)
@@ -142,10 +147,11 @@ class BikeServiceTest {
   fun `modifyBike maps constraint violation to data invalid not server error`() {
     val pathId = UUID_BIKE_A
     val bike = bikeWith(model = "Daytona", id = pathId)
-    val savedEntity = BikeEntity(id = pathId, model = "Daytona")
-    every { repository.existsById(pathId) } returns true
-    every { mapper.map(bike) } returns savedEntity
-    every { repository.save(any()) } throws DataIntegrityViolationException("CONSTRAINT_VIOLATION")
+    val existingEntity = BikeEntity(id = pathId, model = "OldModel")
+    val mappedEntity = BikeEntity(id = pathId, model = "Daytona")
+    every { repository.findById(pathId) } returns Optional.of(existingEntity)
+    every { mapper.map(bike) } returns mappedEntity
+    every { repository.saveAndFlush(any()) } throws DataIntegrityViolationException("CONSTRAINT_VIOLATION")
 
     val ex = Assertions.assertThrows(ServiceException::class.java) {
       bikeService.modifyBike(pathId, bike)

--- a/src/test/kotlin/de/cyclingsir/cetrack/part/domain/PartServiceTest.kt
+++ b/src/test/kotlin/de/cyclingsir/cetrack/part/domain/PartServiceTest.kt
@@ -142,16 +142,18 @@ class PartServiceTest {
     val pathId = UUID_PART_A
     val part = partWith(label = "Tire", model = null)
     val savedEntitySlot = slot<PartEntity>()
+    val foundEntity = PartEntity(pathId, "A", emptyList())
     val savedEntity = PartEntity(id = pathId, label = "Tire", partTypeRelations = emptyList())
 
-    every { partRepository.findById(pathId) } returns Optional.of(PartEntity(pathId, "A", emptyList()))
-    every { partRepository.save(capture(savedEntitySlot)) } returns savedEntity
+    every { partRepository.findById(pathId) } returns Optional.of(foundEntity)
+    every { partRepository.saveAndFlush(capture(savedEntitySlot)) } returns savedEntity
 
     val result = partService.modifyPart(pathId, part)
 
+    Assertions.assertSame(foundEntity, savedEntitySlot.captured)
     Assertions.assertEquals(pathId, savedEntitySlot.captured.id)
     Assertions.assertEquals(pathId, result?.id)
-    verify(exactly = 1) { partRepository.save(any()) }
+    verify(exactly = 1) { partRepository.saveAndFlush(any()) }
   }
 
   @Test
@@ -161,12 +163,12 @@ class PartServiceTest {
     val savedEntity = PartEntity(id = pathId, label = "Tire", partTypeRelations = emptyList())
 
     every { partRepository.findById(pathId) } returns Optional.of(PartEntity(pathId, "A", emptyList()))
-    every { partRepository.save(any()) } returns savedEntity
+    every { partRepository.saveAndFlush(any()) } returns savedEntity
 
     val result = partService.modifyPart(pathId, part)
 
     Assertions.assertEquals(pathId, result?.id)
-    verify(exactly = 1) { partRepository.save(any()) }
+    verify(exactly = 1) { partRepository.saveAndFlush(any()) }
   }
 
   @Test
@@ -178,9 +180,8 @@ class PartServiceTest {
     val body = partWith(label = "Tire", model = null)
     val savedSlot = slot<PartEntity>()
 
-    every { partRepository.existsById(pathId) } returns true
     every { partRepository.findById(pathId) } returns Optional.of(existingEntity)
-    every { partRepository.save(capture(savedSlot)) } answers { savedSlot.captured }
+    every { partRepository.saveAndFlush(capture(savedSlot)) } answers { savedSlot.captured }
 
     partService.modifyPart(pathId, body)
 
@@ -197,9 +198,8 @@ class PartServiceTest {
     val body = partWith(label = "Tire", model = null).copy(partTypeRelations = null)
     val savedSlot = slot<PartEntity>()
 
-    every { partRepository.existsById(pathId) } returns true
     every { partRepository.findById(pathId) } returns Optional.of(existingEntity)
-    every { partRepository.save(capture(savedSlot)) } answers { savedSlot.captured }
+    every { partRepository.saveAndFlush(capture(savedSlot)) } answers { savedSlot.captured }
 
     partService.modifyPart(pathId, body)
 
@@ -300,7 +300,7 @@ class PartServiceTest {
     val part = partWith(label = "Tire", model = null)
     val existingEntity = PartEntity(pathId, "A", emptyList())
     every { partRepository.findById(pathId) } returns Optional.of(existingEntity)
-    every { partRepository.save(any()) } throws DataIntegrityViolationException("CONSTRAINT_VIOLATION")
+    every { partRepository.saveAndFlush(any()) } throws DataIntegrityViolationException("CONSTRAINT_VIOLATION")
 
     val ex = Assertions.assertThrows(ServiceException::class.java) {
       partService.modifyPart(pathId, part)
@@ -315,7 +315,7 @@ class PartServiceTest {
     val part = partWith(label = "Tire", model = null)
     val existingEntity = PartEntity(pathId, "A", emptyList())
     every { partRepository.findById(pathId) } returns Optional.of(existingEntity)
-    every { partRepository.save(any()) } throws RuntimeException("db down")
+    every { partRepository.saveAndFlush(any()) } throws RuntimeException("db down")
 
     val ex = Assertions.assertThrows(ServiceException::class.java) {
       partService.modifyPart(pathId, part)

--- a/src/test/kotlin/de/cyclingsir/cetrack/part/domain/PartTypeServiceTest.kt
+++ b/src/test/kotlin/de/cyclingsir/cetrack/part/domain/PartTypeServiceTest.kt
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.dao.DataIntegrityViolationException
+import java.util.Optional
 import java.util.UUID
 
 @ExtendWith(MockKExtension::class)
@@ -76,13 +77,13 @@ class PartTypeServiceTest {
     val pathId = UUID_PART_TYPE_A
     val partType = partTypeWith(name = "Crank")
 
-    every { repository.existsById(pathId) } returns false
+    every { repository.findById(pathId) } returns Optional.empty()
 
     val ex = Assertions.assertThrows(ServiceException::class.java) {
       partTypeService.modifyPartType(pathId, partType)
     }
     Assertions.assertEquals(ErrorCodesDomain.PART_TYPE_NOT_FOUND.code, ex.getError().code)
-    verify(exactly = 0) { repository.save(any()) }
+    verify(exactly = 0) { repository.saveAndFlush(any()) }
   }
 
   @Test
@@ -90,30 +91,32 @@ class PartTypeServiceTest {
     val pathId = UUID_PART_TYPE_A
     val unidentifiablePartType = partTypeWith(name = "")
 
-    every { repository.existsById(pathId) } returns false
+    every { repository.findById(pathId) } returns Optional.empty()
 
     val ex = Assertions.assertThrows(ServiceException::class.java) {
       partTypeService.modifyPartType(pathId, unidentifiablePartType)
     }
     Assertions.assertEquals(ErrorCodesDomain.PART_TYPE_NOT_FOUND.code, ex.getError().code)
-    verify(exactly = 0) { repository.save(any()) }
+    verify(exactly = 0) { repository.saveAndFlush(any()) }
   }
 
   @Test
   fun `modifyPartType saves entity with path id when body id is null`() {
     val pathId = UUID_PART_TYPE_A
     val partType = partTypeWith(name = "Crank")
+    val existingEntity = PartTypeEntity(id = pathId, name = "OldName", mandatory = false, partTypeRelations = emptyList())
     val savedEntitySlot = slot<PartTypeEntity>()
     val savedEntity = PartTypeEntity(id = pathId, name = "Crank", mandatory = false, partTypeRelations = emptyList())
 
-    every { repository.existsById(pathId) } returns true
-    every { repository.save(capture(savedEntitySlot)) } returns savedEntity
+    every { repository.findById(pathId) } returns Optional.of(existingEntity)
+    every { repository.saveAndFlush(capture(savedEntitySlot)) } returns savedEntity
 
     val result = partTypeService.modifyPartType(pathId, partType)
 
+    Assertions.assertSame(existingEntity, savedEntitySlot.captured)
     Assertions.assertEquals(pathId, savedEntitySlot.captured.id)
     Assertions.assertEquals(pathId, result?.id)
-    verify(exactly = 1) { repository.save(any()) }
+    verify(exactly = 1) { repository.saveAndFlush(any()) }
   }
 
   @Test
@@ -140,8 +143,9 @@ class PartTypeServiceTest {
   fun `modifyPartType maps technical failure to server error`() {
     val pathId = UUID_PART_TYPE_A
     val partType = partTypeWith(name = "Crank")
-    every { repository.existsById(pathId) } returns true
-    every { repository.save(any()) } throws RuntimeException("db down")
+    val existingEntity = PartTypeEntity(id = pathId, name = "OldName", mandatory = false, partTypeRelations = emptyList())
+    every { repository.findById(pathId) } returns Optional.of(existingEntity)
+    every { repository.saveAndFlush(any()) } throws RuntimeException("db down")
 
     val ex = Assertions.assertThrows(ServiceException::class.java) {
       partTypeService.modifyPartType(pathId, partType)
@@ -154,8 +158,9 @@ class PartTypeServiceTest {
   fun `modifyPartType maps constraint violation to data invalid not server error`() {
     val pathId = UUID_PART_TYPE_A
     val partType = partTypeWith(name = "Crank")
-    every { repository.existsById(pathId) } returns true
-    every { repository.save(any()) } throws DataIntegrityViolationException("CONSTRAINT_VIOLATION")
+    val existingEntity = PartTypeEntity(id = pathId, name = "OldName", mandatory = false, partTypeRelations = emptyList())
+    every { repository.findById(pathId) } returns Optional.of(existingEntity)
+    every { repository.saveAndFlush(any()) } throws DataIntegrityViolationException("CONSTRAINT_VIOLATION")
 
     val ex = Assertions.assertThrows(ServiceException::class.java) {
       partTypeService.modifyPartType(pathId, partType)
@@ -168,14 +173,15 @@ class PartTypeServiceTest {
   fun `modifyPartType accepts matching body id and path id`() {
     val pathId = UUID_PART_TYPE_A
     val partType = partTypeWith(name = "Crank", id = pathId)
+    val existingEntity = PartTypeEntity(id = pathId, name = "OldName", mandatory = false, partTypeRelations = emptyList())
     val savedEntity = PartTypeEntity(id = pathId, name = "Crank", mandatory = false, partTypeRelations = emptyList())
 
-    every { repository.existsById(pathId) } returns true
-    every { repository.save(any()) } returns savedEntity
+    every { repository.findById(pathId) } returns Optional.of(existingEntity)
+    every { repository.saveAndFlush(any()) } returns savedEntity
 
     val result = partTypeService.modifyPartType(pathId, partType)
 
     Assertions.assertEquals(pathId, result?.id)
-    verify(exactly = 1) { repository.save(any()) }
+    verify(exactly = 1) { repository.saveAndFlush(any()) }
   }
 }

--- a/src/test/kotlin/de/cyclingsir/cetrack/part/storage/ModifyPartPersistenceTest.kt
+++ b/src/test/kotlin/de/cyclingsir/cetrack/part/storage/ModifyPartPersistenceTest.kt
@@ -1,0 +1,35 @@
+package de.cyclingsir.cetrack.part.storage
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.transaction.annotation.Transactional
+
+@SpringBootTest
+@Transactional
+class ModifyPartPersistenceTest {
+
+    @Autowired
+    private lateinit var repository: PartRepository
+
+    @Test
+    fun `modifyPart issues UPDATE not INSERT and preserves createdAt`() {
+        val initial = PartEntity(id = null, label = "Old Label", partTypeRelations = null)
+        val saved = repository.saveAndFlush(initial)
+        val id = saved.id!!
+        val createdAt = saved.createdAt!!
+
+        Assertions.assertEquals(1L, repository.count())
+
+        val existing = repository.findById(id).get()
+        existing.label = "New Label"
+        repository.saveAndFlush(existing)
+
+        Assertions.assertEquals(1L, repository.count())
+
+        val updated = repository.findById(id).get()
+        Assertions.assertEquals("New Label", updated.label)
+        Assertions.assertEquals(createdAt, updated.createdAt)
+    }
+}


### PR DESCRIPTION
Check-then-use was not atomic: existsById/findById + save(detached) could silently resurrect a concurrently deleted row or map the resulting DataIntegrityViolationException to *_DATA_INVALID (HTTP 400).

Fix: annotate each modify* method @Transactional, load the managed entity via findById instead of existsById, copy scalar fields onto it, and persist with saveAndFlush (forces flush inside the try/catch so genuine constraint violations are still mapped to *_DATA_INVALID). Removed explicit 'final' from PartService to allow CGLIB proxying.

Tests updated to stub saveAndFlush; assertSame added to verify the managed entity is the one saved. New SpringBootTest persistence test confirms UPDATE-not-INSERT and createdAt preservation with real H2.

[Claude Code - model: claude-sonnet-4-6]